### PR TITLE
fix(ci): Add Go installation for macOS FIPS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,14 @@ jobs:
       with:
         targets: ${{ matrix.target }}
 
+    # Go is required for aws-lc-fips-sys FIPS builds
+    - name: Install Go (macOS)
+      if: runner.os == 'macOS'
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+      with:
+        go-version: 'stable'
+        cache: false
+
     - name: Build release artifacts
       run: cargo build --workspace --target ${{ matrix.target }} --release --all-features
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,14 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
 
+      # Go is required for aws-lc-fips-sys FIPS builds
+      - name: Install Go (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+        with:
+          go-version: 'stable'
+          cache: false
+
       - name: Build release
         run: cargo build --workspace --release --target ${{ matrix.target }} --all-features
 


### PR DESCRIPTION
## Summary
- Add Go installation step for macOS runners in release and CI workflows
- Required for `aws-lc-fips-sys` FIPS builds which depend on Go

## Problem
macOS builds in v0.1.2 release failed with:
```
Missing dependency: Go is required for FIPS.
```

## Solution
Added `actions/setup-go@v5` step for macOS runners before the build step in:
- `.github/workflows/release.yml`
- `.github/workflows/ci.yml`

## Test plan
- [ ] CI pipeline passes on macOS targets
- [ ] Release workflow completes successfully for darwin targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)